### PR TITLE
fix(commitlint-config): merge configs when lerna is available

### DIFF
--- a/packages/commitlint-config/index.js
+++ b/packages/commitlint-config/index.js
@@ -7,5 +7,8 @@ try {
 } catch (e) {}
 
 module.exports = isLernaAvailable
-  ? require('@commitlint/config-lerna-scopes')
+  ? require('lodash.merge')(
+      require('@commitlint/config-conventional'),
+      require('@commitlint/config-lerna-scopes'),
+    )
   : require('@commitlint/config-conventional')

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@commitlint/config-conventional": "^8.2.0",
-    "@commitlint/config-lerna-scopes": "^8.2.0"
+    "@commitlint/config-lerna-scopes": "^8.2.0",
+    "lodash.merge": "^4.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8644,6 +8644,11 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.npm.alibaba-inc.com/lodash.merge/download/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=
+
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"


### PR DESCRIPTION
when lerna is available, config-conventional lint is missing

![image](https://user-images.githubusercontent.com/1615364/67006223-23486680-f117-11e9-9d1a-ccfaeeb48149.png)
