### PR TITLE
chore(markuplint-config): disable `required-h1` rule

### DIFF
--- a/.changeset/shiny-bears-sneeze.md
+++ b/.changeset/shiny-bears-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@1stg/markuplint-config": patch
+---
+
+chore(markuplint-config): disable `required-h1` rule

--- a/packages/markuplint-config/base.js
+++ b/packages/markuplint-config/base.js
@@ -10,6 +10,7 @@ const base = {
     'deprecated-element': true,
     'id-duplication': true,
     'required-attr': true,
+    'required-h1': false,
     'use-list': false,
   },
   excludeFiles: ['**/node_modules/**'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the HTML validation configuration to no longer require an H1 element. This change provides greater flexibility in how pages are structured during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->