### PR TITLE
feat(prettier-config): add `go-template` and `jsdoc` plugins

### DIFF
--- a/.changeset/old-tigers-guess.md
+++ b/.changeset/old-tigers-guess.md
@@ -1,5 +1,5 @@
 ---
-"@1stg/remark-preset": patch
+"@1stg/remark-preset": minor
 ---
 
-feat(remark-preset): add `remark-cjk-friendly` support
+feat(remark-preset): add `remark-cjk-friendly` and `cjk-friendly-gfm-strikethrough` plugins

--- a/.changeset/warm-pugs-walk.md
+++ b/.changeset/warm-pugs-walk.md
@@ -1,0 +1,5 @@
+---
+"@1stg/prettier-config": minor
+---
+
+feat(prettier-config): add `go-template` and `jsdoc` plugins

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -44,7 +44,7 @@ module.exports = declare(
     }
 
     /**
-     * presets are processed in last-to-first order
+     * Presets are processed in last-to-first order
      *
      * @see https://babeljs.io/docs/en/presets#preset-ordering
      */

--- a/packages/browserslist-config/alauda.js
+++ b/packages/browserslist-config/alauda.js
@@ -1,4 +1,2 @@
-/**
- * @see http://confluence.alauda.cn/pages/viewpage.action?pageId=67557669
- */
+/** @see http://confluence.alauda.cn/pages/viewpage.action?pageId=67557669 */
 module.exports = ['Chrome >= 85', 'Firefox >= 80']

--- a/packages/eslint-config/_util.js
+++ b/packages/eslint-config/_util.js
@@ -13,9 +13,7 @@ import configPrettier from 'eslint-config-prettier'
 import prettierRecommended from 'eslint-plugin-prettier/recommended'
 import tseslint from 'typescript-eslint'
 
-/**
- * @type {string[]}
- */
+/** @type {string[]} */
 let allowModules = []
 
 if (isMonorepo()) {

--- a/packages/eslint-config/overrides.js
+++ b/packages/eslint-config/overrides.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-/**
- * @import {Linter} from 'eslint'
- */
+/** @import {Linter} from 'eslint' */
 
 import path from 'node:path'
 
@@ -32,18 +30,14 @@ import vueParser from 'vue-eslint-parser'
 
 import { isTsAvailable, magicNumbers, prettierExtends } from './_util.js'
 
-/**
- * @import {TSESLint} from '@typescript-eslint/utils'
- */
+/** @import {TSESLint} from '@typescript-eslint/utils' */
 
 const configFile =
   tryFile(path.resolve('babel.config.js')) ||
   tryFile(path.resolve('.babelrc.js')) ||
   tryPkg('@1stg/babel-preset/config')
 
-/**
- * @satisfies {TSESLint.FlatConfig.Config}
- */
+/** @satisfies {TSESLint.FlatConfig.Config} */
 const jsBase = {
   name: '@1stg/js-base',
   files: ['**/*.{cjs,mjs,js,jsx}'],
@@ -308,9 +302,7 @@ export const ts = tseslint.config(
   },
 )
 
-/**
- * @satisfies {TSESLint.FlatConfig.Config}
- */
+/** @satisfies {TSESLint.FlatConfig.Config} */
 export const dTs = {
   name: '@1stg/d-ts',
   files: ['**/*.d.{cts,mts,ts}', '**/*.d.*.{cts,mts,ts}'],
@@ -530,9 +522,7 @@ const nonSourceRules = /** @type {const} */ ({
   'n/no-unsupported-features/es-builtins': 0,
 })
 
-/**
- * @satisfies {TSESLint.FlatConfig.Config}
- */
+/** @satisfies {TSESLint.FlatConfig.Config} */
 export const test = {
   name: '@1stg/test',
   files: ['**/{__test__,test,tests}/**/*'],
@@ -561,9 +551,7 @@ export const vitest = tseslint.config({
   rules: test.rules,
 })
 
-/**
- * @satisfies {TSESLint.FlatConfig.Config}
- */
+/** @satisfies {TSESLint.FlatConfig.Config} */
 export const script = {
   name: '@1stg/script',
   files: ['**/scripts/**/*'],
@@ -572,9 +560,7 @@ export const script = {
 
 export const scripts = script
 
-/**
- * @satisfies {TSESLint.FlatConfig.Config}
- */
+/** @satisfies {TSESLint.FlatConfig.Config} */
 export const story = {
   name: '@1stg/story',
   files: ['**/.storybook/**/*', '**/stories/**/*'],
@@ -583,9 +569,7 @@ export const story = {
 
 export const stories = story
 
-/**
- * @satisfies {TSESLint.FlatConfig.Config}
- */
+/** @satisfies {TSESLint.FlatConfig.Config} */
 export const config = {
   name: '@1stg/config',
   files: ['**/.*.js', '**/*.config.{js,ts}'],

--- a/packages/markuplint-config/base.js
+++ b/packages/markuplint-config/base.js
@@ -1,6 +1,6 @@
 /**
- * @import {Config} from '@markuplint/ml-config'
  * @type {Config}
+ * @import {Config} from '@markuplint/ml-config'
  */
 const base = {
   extends: ['markuplint:recommended'],

--- a/packages/markuplint-config/vue.js
+++ b/packages/markuplint-config/vue.js
@@ -1,8 +1,8 @@
 import base from './base.js'
 
 /**
- * @import {Config} from '@markuplint/core'
  * @type {Config}
+ * @import {Config} from '@markuplint/core'
  */
 const vue = {
   ...base,

--- a/packages/postcss-config/index.js
+++ b/packages/postcss-config/index.js
@@ -1,8 +1,8 @@
 const { NODE_ENV, __DEV__, __PROD__ } = require('@pkgr/utils')
 
 /**
- * @import {ConfigFn, ConfigPlugin} from 'postcss-load-config'
  * @type {ConfigFn}
+ * @import {ConfigFn, ConfigPlugin} from 'postcss-load-config'
  */
 const config = ({
   advanced,
@@ -14,9 +14,7 @@ const config = ({
   url,
   ...options
 } = {}) => {
-  /**
-   * @type {ConfigPlugin[]}
-   */
+  /** @type {ConfigPlugin[]} */
   const plugins = [
     require('postcss-preset-env')(presetEnv),
     require('postcss-import')(importOptions),

--- a/packages/prettier-config/base.js
+++ b/packages/prettier-config/base.js
@@ -4,9 +4,7 @@ import { iniRcFiles, jsoncFiles, nonJsonRcFiles, shRcFiles } from '@1stg/config'
 
 const require = createRequire(import.meta.url)
 
-/**
- * @type {import('prettier').Config}
- */
+/** @type {import('prettier').Config} */
 export default {
   arrowParens: 'avoid',
   semi: false,
@@ -16,9 +14,7 @@ export default {
   xmlWhitespaceSensitivity: 'ignore',
   plugins: await Promise.all(
     Object.keys(require('./package.json').dependencies).map(async pkgName => {
-      /**
-       * @type {import('prettier').Plugin}
-       */
+      /** @type {import('prettier').Plugin} */
       const pkg = await import(pkgName)
       return pkg.default || pkg
     }),

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -7,6 +7,9 @@
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/configs",
   "license": "MIT",
+  "engines": {
+    "node": ">=14.8.0"
+  },
   "main": "./index.js",
   "exports": {
     ".": "./index.js",
@@ -28,7 +31,9 @@
     "@prettier/plugin-pug": "^3.3.0",
     "@prettier/plugin-ruby": "^4.0.4",
     "@prettier/plugin-xml": "^3.4.1",
+    "prettier-plugin-go-template": "^0.0.15",
     "prettier-plugin-ini": "^1.3.0",
+    "prettier-plugin-jsdoc": "^1.3.2",
     "prettier-plugin-pkg": "^0.19.0",
     "prettier-plugin-properties": "^0.3.0",
     "prettier-plugin-sh": "^0.17.2",

--- a/packages/stylelint-config/_overrides.js
+++ b/packages/stylelint-config/_overrides.js
@@ -13,9 +13,9 @@ const disablePrettierOptions = !preferPrettier &&
   }
 
 /**
- * @import {Config} from 'stylelint'
  * @param {boolean} loose
  * @returns {Config} Stylelint configuration
+ * @import {Config} from 'stylelint'
  */
 export const overrides = loose => ({
   ...base,

--- a/packages/stylelint-config/base.js
+++ b/packages/stylelint-config/base.js
@@ -5,8 +5,8 @@ const isAngularAvailable = isPkgAvailable('@angular/core')
 const isVueAvailable = isPkgAvailable('vue')
 
 /**
- * @import {Config} from 'stylelint'
  * @type {Config}
+ * @import {Config} from 'stylelint'
  */
 const base = {
   extends: [

--- a/packages/stylelint-config/modules.js
+++ b/packages/stylelint-config/modules.js
@@ -1,6 +1,6 @@
 /**
- * @import {Config} from 'stylelint'
  * @type {Config}
+ * @import {Config} from 'stylelint'
  */
 const modules = {
   rules: {

--- a/packages/stylelint-config/scss/base.js
+++ b/packages/stylelint-config/scss/base.js
@@ -1,6 +1,6 @@
 /**
- * @import {Config} from 'stylelint'
  * @type {Config}
+ * @import {Config} from 'stylelint'
  */
 const base = {
   customSyntax: 'postcss-scss',

--- a/packages/stylelint-config/scss/loose.js
+++ b/packages/stylelint-config/scss/loose.js
@@ -1,8 +1,8 @@
 import base from './base.js'
 
 /**
- * @import {Config} from 'stylelint'
  * @type {Config}
+ * @import {Config} from 'stylelint'
  */
 const loose = {
   ...base,

--- a/tests/_test.ts
+++ b/tests/_test.ts
@@ -1,6 +1,4 @@
-/**
- * @deprecated This has been deprecated, no not use it
- */
+/** @deprecated This has been deprecated, no not use it */
 export const content = 'Hello World'
 
 export interface PartialObserver<T> {

--- a/tests/test2.ts
+++ b/tests/test2.ts
@@ -10,9 +10,7 @@ import { content, TestCase } from './_test'
 
 promisify(fs.readFile)
 
-/**
- * @deprecated
- */
+/** @deprecated */
 class Basic {
   // eslint-disable-next-line sonarjs/deprecation -- testing
   prop: string = content

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,7 +224,9 @@ __metadata:
     "@prettier/plugin-pug": "npm:^3.3.0"
     "@prettier/plugin-ruby": "npm:^4.0.4"
     "@prettier/plugin-xml": "npm:^3.4.1"
+    prettier-plugin-go-template: "npm:^0.0.15"
     prettier-plugin-ini: "npm:^1.3.0"
+    prettier-plugin-jsdoc: "npm:^1.3.2"
     prettier-plugin-pkg: "npm:^0.19.0"
     prettier-plugin-properties: "npm:^0.3.0"
     prettier-plugin-sh: "npm:^0.17.2"
@@ -5854,6 +5856,13 @@ __metadata:
   dependencies:
     is-windows: "npm:^1.0.0"
   checksum: 10c0/7335130729d59a14b8e4753fea180ca84e287cccc20cb5f2438a95667abc5810327c414eee7b3c79ed1b5a348a40284ea872958f50caba69432c40405eb0acce
+  languageName: node
+  linkType: hard
+
+"binary-searching@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "binary-searching@npm:2.0.5"
+  checksum: 10c0/914ccf15d4c989a8900e5617e2b6ec77a016f894b3833eaa5720a310214420dbd5d8eb577c158f99d25769968225c522cc37580c8d2ed46cc469f9d0365b7f15
   languageName: node
   linkType: hard
 
@@ -13750,12 +13759,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-plugin-go-template@npm:^0.0.15":
+  version: 0.0.15
+  resolution: "prettier-plugin-go-template@npm:0.0.15"
+  dependencies:
+    ulid: "npm:^2.3.0"
+  peerDependencies:
+    prettier: ^3.0.0
+  checksum: 10c0/1c8a65535ded9694a3eca929a4b8ae4220be777f09df3bf3a954faa6524e3ecb99973ce8c74fa2690676bc6c0d81ba16a1faa5673f7ba945dab5adee02d8ad74
+  languageName: node
+  linkType: hard
+
 "prettier-plugin-ini@npm:^1.3.0":
   version: 1.3.0
   resolution: "prettier-plugin-ini@npm:1.3.0"
   dependencies:
     prettier: "npm:>=3.0.0-alpha.3"
   checksum: 10c0/db5580a903cf5dadd89f33a7317aa2cc13da6b81c623a5a8786b2610521be834516ca393c1a1535603f55435f95ab372b9199bca1e8091600dad523cd3ebe4b3
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-jsdoc@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "prettier-plugin-jsdoc@npm:1.3.2"
+  dependencies:
+    binary-searching: "npm:^2.0.5"
+    comment-parser: "npm:^1.4.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+  peerDependencies:
+    prettier: ^3.0.0
+  checksum: 10c0/53d15897b75077f172d52e61e17e7f39314c9268e6c65128f825e56fd7b59669b06a286a88bec6742149b456b7c3d8f88ca0c2ab7797a623c0524c821e2d2f60
   languageName: node
   linkType: hard
 
@@ -16625,6 +16658,15 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  languageName: node
+  linkType: hard
+
+"ulid@npm:^2.3.0":
+  version: 2.4.0
+  resolution: "ulid@npm:2.4.0"
+  bin:
+    ulid: bin/cli.js
+  checksum: 10c0/96f7597a2f09dadd380707a0755753d85717059deae54a9e28b6cbc34c02ef211dd1d1dcbfa8bd557d12309f174b87f3ba5f45d6b67573d1a2da202b5a0c9319
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
related #333
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `go-template` and `jsdoc` plugins to `prettier-config` and update Node.js version requirement.
> 
>   - **Plugins**:
>     - Add `prettier-plugin-go-template` version `^0.0.15` to `dependencies` in `package.json`.
>     - Add `prettier-plugin-jsdoc` version `^1.3.2` to `dependencies` in `package.json`.
>   - **Engines**:
>     - Update `engines` field in `package.json` to require Node.js version `>=14.8.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for c93509655bd4921e941e15ac920719bc4bbbf6c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced markdown processing with improved support for CJK text by adding an extra plugin.
  - Expanded formatting capabilities with new configuration options for Go templates and JSDoc comments, along with an updated Node.js version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->