### PR TITLE
feat: add `prettier-plugin-jsdoc-type`

### DIFF
--- a/.changeset/smooth-ravens-lie.md
+++ b/.changeset/smooth-ravens-lie.md
@@ -1,0 +1,5 @@
+---
+"@1stg/prettier-config": patch
+---
+
+feat(prettier-config): add `prettier-plugin-jsdoc-type`

--- a/packages/eslint-config/js-base.js
+++ b/packages/eslint-config/js-base.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @import {TSESLint} from '@typescript-eslint/utils' */
+/** @import { TSESLint } from '@typescript-eslint/utils' */
 
 import { tryFile, tryPkg, tryRequirePkg } from '@pkgr/utils'
 

--- a/packages/eslint-config/overrides.js
+++ b/packages/eslint-config/overrides.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @import {TSESLint} from '@typescript-eslint/utils' */
+/** @import { TSESLint } from '@typescript-eslint/utils' */
 
 import { jsoncFiles, nonJsonRcFiles, preferPrettier } from '@1stg/config'
 import { isPkgAvailable } from '@pkgr/utils'

--- a/packages/eslint-config/test.js
+++ b/packages/eslint-config/test.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @import {TSESLint} from '@typescript-eslint/utils' */
+/** @import { TSESLint } from '@typescript-eslint/utils' */
 
 import { nonSourceRules } from './_util.js'
 

--- a/packages/markuplint-config/base.js
+++ b/packages/markuplint-config/base.js
@@ -1,6 +1,6 @@
 /**
  * @type {Config}
- * @import {Config} from '@markuplint/ml-config'
+ * @import { Config } from '@markuplint/ml-config'
  */
 const base = {
   extends: ['markuplint:recommended'],

--- a/packages/markuplint-config/vue.js
+++ b/packages/markuplint-config/vue.js
@@ -2,7 +2,7 @@ import base from './base.js'
 
 /**
  * @type {Config}
- * @import {Config} from '@markuplint/core'
+ * @import { Config } from '@markuplint/core'
  */
 const vue = {
   ...base,

--- a/packages/postcss-config/index.js
+++ b/packages/postcss-config/index.js
@@ -2,7 +2,7 @@ const { NODE_ENV, __DEV__, __PROD__ } = require('@pkgr/utils')
 
 /**
  * @type {ConfigFn}
- * @import {ConfigFn, ConfigPlugin} from 'postcss-load-config'
+ * @import { ConfigFn, ConfigPlugin } from 'postcss-load-config'
  */
 const config = ({
   advanced,

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -35,6 +35,7 @@
     "prettier-plugin-go-template": "^0.0.15",
     "prettier-plugin-ini": "^1.3.0",
     "prettier-plugin-jsdoc": "^1.3.2",
+    "prettier-plugin-jsdoc-type": "^0.1.5",
     "prettier-plugin-pkg": "^0.19.0",
     "prettier-plugin-properties": "^0.3.0",
     "prettier-plugin-sh": "^0.17.2",

--- a/packages/stylelint-config/_overrides.js
+++ b/packages/stylelint-config/_overrides.js
@@ -15,7 +15,7 @@ const disablePrettierOptions = !preferPrettier &&
 /**
  * @param {boolean} loose
  * @returns {Config} Stylelint configuration
- * @import {Config} from 'stylelint'
+ * @import { Config } from 'stylelint'
  */
 export const overrides = loose => ({
   ...base,

--- a/packages/stylelint-config/base.js
+++ b/packages/stylelint-config/base.js
@@ -6,7 +6,7 @@ const isVueAvailable = isPkgAvailable('vue')
 
 /**
  * @type {Config}
- * @import {Config} from 'stylelint'
+ * @import { Config } from 'stylelint'
  */
 const base = {
   extends: [

--- a/packages/stylelint-config/modules.js
+++ b/packages/stylelint-config/modules.js
@@ -1,6 +1,6 @@
 /**
  * @type {Config}
- * @import {Config} from 'stylelint'
+ * @import { Config } from 'stylelint'
  */
 const modules = {
   rules: {

--- a/packages/stylelint-config/scss/base.js
+++ b/packages/stylelint-config/scss/base.js
@@ -1,6 +1,6 @@
 /**
  * @type {Config}
- * @import {Config} from 'stylelint'
+ * @import { Config } from 'stylelint'
  */
 const base = {
   customSyntax: 'postcss-scss',

--- a/packages/stylelint-config/scss/loose.js
+++ b/packages/stylelint-config/scss/loose.js
@@ -2,7 +2,7 @@ import base from './base.js'
 
 /**
  * @type {Config}
- * @import {Config} from 'stylelint'
+ * @import { Config } from 'stylelint'
  */
 const loose = {
   ...base,

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,6 +256,7 @@ __metadata:
     prettier-plugin-go-template: "npm:^0.0.15"
     prettier-plugin-ini: "npm:^1.3.0"
     prettier-plugin-jsdoc: "npm:^1.3.2"
+    prettier-plugin-jsdoc-type: "npm:^0.1.5"
     prettier-plugin-pkg: "npm:^0.19.0"
     prettier-plugin-properties: "npm:^0.3.0"
     prettier-plugin-sh: "npm:^0.17.2"
@@ -7037,7 +7038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"comment-parser@npm:1.4.1, comment-parser@npm:^1.4.0":
+"comment-parser@npm:1.4.1, comment-parser@npm:^1.4.0, comment-parser@npm:^1.4.1":
   version: 1.4.1
   resolution: "comment-parser@npm:1.4.1"
   checksum: 10c0/d6c4be3f5be058f98b24f2d557f745d8fe1cc9eb75bebbdccabd404a0e1ed41563171b16285f593011f8b6a5ec81f564fb1f2121418ac5cbf0f49255bf0840dd
@@ -14881,6 +14882,18 @@ __metadata:
   dependencies:
     prettier: "npm:>=3.0.0-alpha.3"
   checksum: 10c0/db5580a903cf5dadd89f33a7317aa2cc13da6b81c623a5a8786b2610521be834516ca393c1a1535603f55435f95ab372b9199bca1e8091600dad523cd3ebe4b3
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-jsdoc-type@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "prettier-plugin-jsdoc-type@npm:0.1.5"
+  dependencies:
+    comment-parser: "npm:^1.4.1"
+  peerDependencies:
+    prettier: ">=3.5.3"
+    typescript: ">=5.8.2"
+  checksum: 10c0/b14f5cf12d76dab8c35d5b9edba25b382ed41291fb5814b39472251c86b8a2285e2161036dc6f7cd6fdbc17959ae6cef929c6920658ce0b5c38682f52f79c3ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `prettier-plugin-jsdoc-type` to `dependencies` in `package.json`.
> 
>   - **Dependencies**:
>     - Add `prettier-plugin-jsdoc-type` version `^0.1.5` to `dependencies` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for 4fbd82128563c821323b0febabbf857db94d61af. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated an enhanced tool for formatting documentation comments, ensuring improved consistency with updated coding standards.
- **Style**
	- Applied standardized formatting adjustments across configuration files to boost overall readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->