### PR TITLE
fix: disable `jsdoc/tag-lines` which conflicts with `prettier-plugin-jsdoc`

### DIFF
--- a/.changeset/funny-buckets-provide.md
+++ b/.changeset/funny-buckets-provide.md
@@ -1,0 +1,5 @@
+---
+"@1stg/eslint-config": patch
+---
+
+fix: disable `jsdoc/tag-lines` which conflicts with `prettier-plugin-jsdoc`

--- a/packages/eslint-config/js.js
+++ b/packages/eslint-config/js.js
@@ -16,7 +16,7 @@ export const js = tseslint.config({
     ...jsBase.rules,
     'jsdoc/require-jsdoc': 0,
     'jsdoc/require-param-description': 0,
-    'jsdoc/tag-lines': [1, 'never', { startLines: 1 }],
+    'jsdoc/tag-lines': 0, // conflict with `prettier-plugin-jsdoc`
   },
   settings: isTsAvailable ? { jsdoc: { mode: 'typescript' } } : undefined,
 })

--- a/tests/test.cjs
+++ b/tests/test.cjs
@@ -1,0 +1,41 @@
+// @ts-check
+
+const { performance } = require('node:perf_hooks')
+
+const RUN_TIMES = +(process.env.RUN_TIMES || 1000)
+
+/**
+ * @param {string} name
+ *
+ * @typedef {{ loadTime: number; runTime: number; totalTime: number } | void} PerfResult
+ * @returns {PerfResult | void} Perf result
+ */
+exports.perfCase = name => {
+  const loadStartTime = performance.now()
+
+  let syncFn
+
+  try {
+    syncFn = require(`./${name}.cjs`)
+  } catch {
+    return
+  }
+
+  const loadTime = performance.now() - loadStartTime
+
+  let i = RUN_TIMES
+
+  const runStartTime = performance.now()
+
+  while (i-- > 0) {
+    syncFn(__filename)
+  }
+
+  const runTime = performance.now() - runStartTime
+
+  return {
+    loadTime,
+    runTime,
+    totalTime: runTime + loadTime,
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disable `jsdoc/tag-lines` in ESLint config due to conflict with `prettier-plugin-jsdoc` and add performance testing in `test.cjs`.
> 
>   - **ESLint Configuration**:
>     - Disable `jsdoc/tag-lines` rule in `js.js` due to conflict with `prettier-plugin-jsdoc`.
>   - **Testing**:
>     - Add `test.cjs` to measure performance of synchronous functions using `perf_hooks`.
>     - Defines `perfCase` function to load and execute a module multiple times, returning performance metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for 5bb9bc571d52a1a0895e8fe3298c8d9ce0b884c1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the linting configuration to resolve conflicts between documentation formatting tools, ensuring a smoother development process.
- **Tests**
  - Introduced a performance testing utility that measures module load and execution times, providing enhanced insights into runtime performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->