### PR TITLE
fix(prettier-config): filter out non `prettier` related packages

### DIFF
--- a/.changeset/nasty-actors-ring.md
+++ b/.changeset/nasty-actors-ring.md
@@ -1,0 +1,5 @@
+---
+"@1stg/prettier-config": patch
+---
+
+fix: filter out non `prettier` related packages

--- a/packages/prettier-config/base.js
+++ b/packages/prettier-config/base.js
@@ -1,10 +1,17 @@
+// @ts-check
+
+/**
+ * @typedef {Plugin_ & { default?: Plugin_ }} Plugin
+ * @import { Config, Plugin as Plugin_ } from 'prettier'
+ */
+
 import { createRequire } from 'node:module'
 
 import { iniRcFiles, jsoncFiles, nonJsonRcFiles, shRcFiles } from '@1stg/config'
 
 const require = createRequire(import.meta.url)
 
-/** @type {import('prettier').Config} */
+/** @type {Config} */
 export default {
   arrowParens: 'avoid',
   semi: false,
@@ -13,11 +20,13 @@ export default {
   trailingComma: 'all',
   xmlWhitespaceSensitivity: 'ignore',
   plugins: await Promise.all(
-    Object.keys(require('./package.json').dependencies).map(async pkgName => {
-      /** @type {import('prettier').Plugin} */
-      const pkg = await import(pkgName)
-      return pkg.default || pkg
-    }),
+    Object.keys(require('./package.json').dependencies)
+      .filter(pkgName => /\bprettier\b/.test(pkgName))
+      .map(async pkgName => {
+        /** @type {Plugin} */
+        const pkg = await import(pkgName)
+        return pkg.default || pkg
+      }),
   ),
   overrides: [
     {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Filters dependencies in `base.js` to only load Prettier-related packages as plugins, improving efficiency.
> 
>   - **Behavior**:
>     - Filters dependencies in `base.js` to only include those with 'prettier' in their names for the `plugins` array.
>     - Improves efficiency by excluding non-Prettier related packages from being loaded as plugins.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for 0cbd822165f9c9af446204da0c07d183003adef8. You can [customize](https://app.ellipsis.dev/1stG/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where non-Prettier-related packages were incorrectly included as plugins, ensuring only relevant Prettier plugins are loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->