### PR TITLE
feat(prettier-config): use `require(ESM)` first and fallback to top level `await`

### DIFF
--- a/.changeset/happy-cycles-count.md
+++ b/.changeset/happy-cycles-count.md
@@ -1,5 +1,5 @@
 ---
-"@1stg/prettier-config": patch
+"@1stg/prettier-config": minor
 ---
 
 feat: use `require(ESM)` first and fallback to top level `await`

--- a/.changeset/happy-cycles-count.md
+++ b/.changeset/happy-cycles-count.md
@@ -1,0 +1,5 @@
+---
+"@1stg/prettier-config": patch
+---
+
+feat: use `require(ESM)` first and fallback to top level `await`

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 !.yarn/releases
 !.yarn/plugins
 !.yarn/sdks
+.idea
+*.iml
 *.log
 *.tsbuildinfo
 .*cache


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `base.js`, plugins are now loaded using `require` first, with a fallback to `await import` if `require` fails, improving compatibility with ESM environments.
> 
>   - **Behavior**:
>     - In `base.js`, plugins are now loaded using `require` first, with a fallback to `await import` if `require` fails.
>     - This change affects how dependencies with `prettier` in their name are loaded from `package.json`.
>   - **Code Structure**:
>     - Introduces a `try-catch` block to handle the fallback mechanism for loading plugins.
>     - Refactors plugin loading logic into a separate `dependencies` array and `plugins` variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for 02e25320c9ebab768af64f9046671c28b93457b0. You can [customize](https://app.ellipsis.dev/1stG/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for loading ECMAScript module plugins by first attempting synchronous loading and falling back to asynchronous loading if necessary.

- **Chores**
  - Updated `.gitignore` to exclude JetBrains IDE settings and module files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->