### PR TITLE
feat(eslint-config): migrate `project` to `projectService` for TypeScript

### DIFF
--- a/.changeset/forty-colts-laugh.md
+++ b/.changeset/forty-colts-laugh.md
@@ -1,0 +1,5 @@
+---
+"@1stg/eslint-config": minor
+---
+
+feat: migrate `project` to `projectService` for TypeScript

--- a/packages/eslint-config/ts-base.js
+++ b/packages/eslint-config/ts-base.js
@@ -25,7 +25,7 @@ export const tsBase = tseslint.config({
   files: ['**/*.{cts,mts,ts,tsx}'],
   languageOptions: {
     parserOptions: {
-      project,
+      projectService: true,
     },
   },
   extends: [

--- a/packages/eslint-config/vue.js
+++ b/packages/eslint-config/vue.js
@@ -39,6 +39,7 @@ export const vue = tseslint.config(
         languageOptions: {
           parser: vueParser,
           parserOptions: {
+            ...tsBase[0].languageOptions?.parserOptions,
             parser: tseslint.parser,
             extraFileExtensions: ['.vue'],
           },


### PR DESCRIPTION
close #366
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrate TypeScript ESLint configuration from `project` to `projectService` in `ts-base.js` and `vue.js`.
> 
>   - **Behavior**:
>     - Migrates from `project` to `projectService` in TypeScript ESLint configuration.
>     - Affects `tsBase` in `ts-base.js` and `vue` in `vue.js`.
>   - **Configuration**:
>     - Updates `parserOptions` to use `projectService: true` in `ts-base.js`.
>     - Extends `parserOptions` in `vue.js` to include `tsBase` settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for c883d0fd00d4c1731f2c70bac8d147950555ab61. You can [customize](https://app.ellipsis.dev/1stG/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->