### PR TITLE
feat(eslint-config)!: use `n.convertPath` setting for hashbang rule

### DIFF
--- a/.changeset/twelve-pianos-hug.md
+++ b/.changeset/twelve-pianos-hug.md
@@ -1,0 +1,5 @@
+---
+"@1stg/eslint-config": major
+---
+
+feat!: use `n.convertPath` setting for hashbang rule

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -52,7 +52,13 @@ export const base = tseslint.config([
         'node_modules/@d-ts',
         'node_modules/@types',
       ],
-      'import-x/resolver-next': [createTypeScriptImportResolver()],
+      'import-x/resolver-next': createTypeScriptImportResolver(),
+      n: {
+        convertPath: {
+          '**/bin.ts': [String.raw`^(src/)?bin\.ts$`, 'lib/bin.js'],
+          '**/cli.ts': [String.raw`^(src/)?cli\.ts$`, 'lib/cli.js'],
+        },
+      },
     },
     languageOptions: {
       sourceType: 'module',

--- a/packages/eslint-config/overrides.js
+++ b/packages/eslint-config/overrides.js
@@ -27,11 +27,6 @@ import { resolveSettings, tsBase } from './ts-base.js'
 export const ts = tseslint.config(
   tsBase,
   {
-    name: '@1stg/cli',
-    files: ['**/{bin,cli}.ts'],
-    rules: { 'n/hashbang': 0 },
-  },
-  {
     name: '@1stg/code-block',
     files: ['**/*.{md,mdx}/**/*.{cts,mts,ts,tsx}'],
     languageOptions: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `n.convertPath` setting for hashbang rule in ESLint config, converting `bin.ts` and `cli.ts` paths, and removes related overrides.
> 
>   - **Behavior**:
>     - Introduces `n.convertPath` setting in `base.js` for hashbang rule, converting `bin.ts` to `lib/bin.js` and `cli.ts` to `lib/cli.js`.
>     - Removes hashbang rule overrides in `overrides.js` for `@1stg/cli`.
>   - **Misc**:
>     - Adds changeset `twelve-pianos-hug.md` indicating a major change for `@1stg/eslint-config`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for d1ed6476bbf25a032078a544d7b84edbb3ed31d1. You can [customize](https://app.ellipsis.dev/1stG/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated linting configuration to improve handling of hashbang lines in CLI and binary files, using new path conversion settings.
- **Breaking Changes**
  - Removed previous override that disabled hashbang rule for certain files; projects may need to update their configurations to align with the new approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->