### PR TITLE
fix(nano-staged): clarify correct engines field due to `1stg/prettier-config`

### DIFF
--- a/.changeset/rotten-clocks-know.md
+++ b/.changeset/rotten-clocks-know.md
@@ -1,0 +1,7 @@
+---
+"@1stg/app-config": minor
+"@1stg/common-config": minor
+"@1stg/nano-staged": minor
+---
+
+fix: clarify correct engines field due to `1stg/prettier-config`

--- a/packages/nano-staged/package.json
+++ b/packages/nano-staged/package.json
@@ -9,7 +9,7 @@
   "funding": "https://opencollective.com/configs",
   "license": "MIT",
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "main": "index.js",
   "exports": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `engines.node` in `@1stg/nano-staged` to specify compatible Node.js versions and add changeset for minor version updates.
> 
>   - **Engines Field Update**:
>     - Updated `engines.node` in `package.json` for `@1stg/nano-staged` to `^18.18.0 || ^20.9.0 || >=21.1.0`.
>   - **Changeset**:
>     - Added `rotten-clocks-know.md` to indicate minor version updates for `@1stg/app-config`, `@1stg/common-config`, and `@1stg/nano-staged`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=1stG%2Fconfigs&utm_source=github&utm_medium=referral)<sup> for 396e436f1dd9257419bde8dce4f222203b5b51e0. You can [customize](https://app.ellipsis.dev/1stG/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->